### PR TITLE
fix: avoid NamedTuple merge

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: json-schema
-version: 1.2.1
+version: 1.3.0
 
 development_dependencies:
   ameba:

--- a/spec/json_schema_spec.cr
+++ b/spec/json_schema_spec.cr
@@ -12,7 +12,7 @@ describe JSON::Schema do
     UUID.json_schema.should eq({type: "string", format: "uuid"})
 
     TestEnum.json_schema.should eq({type: "string", enum: ["option1", "option2"]})
-    Hash(String, Int32 | Float32).json_schema.should eq({type: "object", additionalProperties: {anyOf: [{type: "number", format: "Float32"}, {type: "integer", format: "Int32"}]}})
+    Hash(String, Int32 | Float32).json_schema.should eq({type: "object", additionalProperties: {anyOf: { {type: "number", format: "Float32"}, {type: "integer", format: "Int32"} }}})
 
     TestGenericInheritance.json_schema.should eq({type: "object", additionalProperties: {type: "integer", format: "Int32"}})
 
@@ -25,14 +25,14 @@ describe JSON::Schema do
     Array(String | Int32).json_schema.should eq({
       type:  "array",
       items: {
-        anyOf: [{type: "integer", format: "Int32"}, {type: "string"}],
+        anyOf: { {type: "integer", format: "Int32"}, {type: "string"} },
       },
     })
 
     Set(String | Int32).json_schema.should eq({
       type:  "array",
       items: {
-        anyOf: [{type: "integer", format: "Int32"}, {type: "string"}],
+        anyOf: { {type: "integer", format: "Int32"}, {type: "string"} },
       },
     })
   end
@@ -48,7 +48,7 @@ describe JSON::Schema do
         integer:  {type: "integer", format: "Int32", minimum: 0, maximum: 100},
         bool:     {type: "boolean"},
         null:     {type: "null"},
-        optional: {anyOf: [{type: "integer", format: "Int64"}, {type: "null"}]},
+        optional: {anyOf: { {type: "integer", format: "Int64"}, {type: "null"} }},
         hash:     {type: "object", additionalProperties: {type: "string"}},
       },
       required: ["options", "string", "symbol", "time", "integer", "bool", "hash"],
@@ -69,38 +69,38 @@ describe JSON::Schema do
             integer:  {type: "integer", format: "Int32", minimum: 0, maximum: 100},
             bool:     {type: "boolean"},
             null:     {type: "null"},
-            optional: {anyOf: [{type: "integer", format: "Int64"}, {type: "null"}]},
+            optional: {anyOf: { {type: "integer", format: "Int64"}, {type: "null"} }},
             hash:     {type: "object", additionalProperties: {type: "string"}},
           },
           required: ["options", "string", "symbol", "time", "integer", "bool", "hash"],
         },
-        array:       {type: "array", items: {anyOf: [{type: "integer", format: "Int32"}, {type: "string"}]}},
-        tuple:       {type: "array", items: [{type: "string"}, {type: "integer", format: "Int32"}, {type: "number", format: "Float64"}]},
+        array:       {type: "array", items: {anyOf: { {type: "integer", format: "Int32"}, {type: "string"} }}},
+        tuple:       {type: "array", items: { {type: "string"}, {type: "integer", format: "Int32"}, {type: "number", format: "Float64"} }},
         named_tuple: {type: "object", properties: {test: {type: "string"}, other: {type: "integer", format: "Int64"}}, required: ["test", "other"]},
-        union_type:  {anyOf: [{type: "boolean"}, {type: "integer", format: "Int64"}, {type: "string"}], description: "a string an int or a bool"},
+        union_type:  {anyOf: { {type: "boolean"}, {type: "integer", format: "Int64"}, {type: "string"} }, description: "a string an int or a bool"},
       },
       required: ["sub_object", "array", "tuple", "named_tuple", "union_type"],
     })
   end
 
   it "works with OpenAPI modifications" do
-    ::JSON::Schema.introspect(Int32?, openapi: true).should eq({type: "integer", format: "Int32", nullable: true})
-    ::JSON::Schema.introspect((String | Int32?), openapi: true).should eq({anyOf: [{type: "integer", format: "Int32"}, {type: "string"}], nullable: true})
+    ::JSON::Schema.introspect(Int32?, openapi: true).should eq({"type" => "integer", "format" => "Int32", "nullable" => true})
+    ::JSON::Schema.introspect((String | Int32?), openapi: true).should eq({anyOf: { {type: "integer", format: "Int32"}, {type: "string"} }, nullable: true})
     ::JSON::Schema.introspect(Example1?, openapi: true).should eq({
-      type:       "object",
-      properties: {
-        options:  {type: "string", enum: ["option1", "option2"]},
-        string:   {type: "string"},
-        symbol:   {type: "string", format: "custom"},
-        time:     {type: "integer", format: "Int64"},
-        integer:  {type: "integer", format: "Int32", minimum: 0, maximum: 100},
-        bool:     {type: "boolean"},
-        null:     {type: "null"},
-        optional: {type: "integer", format: "Int64", nullable: true},
-        hash:     {type: "object", additionalProperties: {type: "string"}},
+      "type"       => "object",
+      "properties" => {
+        "options"  => {"type" => "string", "enum" => ["option1", "option2"]},
+        "string"   => {"type" => "string"},
+        "symbol"   => {"type" => "string", "format" => "custom"},
+        "time"     => {"type" => "integer", "format" => "Int64"},
+        "integer"  => {"type" => "integer", "format" => "Int32", "minimum" => 0, "maximum" => 100},
+        "bool"     => {"type" => "boolean"},
+        "null"     => {"type" => "null"},
+        "optional" => {"type" => "integer", "format" => "Int64", "nullable" => true},
+        "hash"     => {"type" => "object", "additionalProperties" => {"type" => "string"}},
       },
-      required: ["options", "string", "symbol", "time", "integer", "bool", "hash"],
-      nullable: true,
+      "required" => ["options", "string", "symbol", "time", "integer", "bool", "hash"],
+      "nullable" => true,
     })
   end
 end

--- a/src/json-schema.cr
+++ b/src/json-schema.cr
@@ -83,19 +83,19 @@ module JSON
             {% end %}
           {% end %}
         {% elsif klass.union? %}
-          { anyOf: [
+          { anyOf: {
             {% for type in klass.union_types %}
               {% if openapi.nil? || type.stringify != "Nil" %}
                 ::JSON::Schema.introspect({{type}}, nil, {{openapi}}),
               {% end %}
             {% end %}
-          ]{% if !openapi.nil? && nillable %}, nullable: true{% end %}{% if description %}, description: {{description}}{% end %} }
+          }{% if !openapi.nil? && nillable %}, nullable: true{% end %}{% if description %}, description: {{description}}{% end %} }
         {% elsif klass_name.starts_with? "Tuple(" %}
-          %has_items = [
+          %has_items = {
             {% for generic in klass.type_vars %}
               ::JSON::Schema.introspect({{generic}}, nil, {{openapi}}),
             {% end %}
-          ]
+          }
           {type: "array"{% if description %}, description: {{description}}{% end %}, items: %has_items}
         {% elsif klass_name.starts_with? "NamedTuple(" %}
           {% if klass.keys.empty? %}
@@ -141,7 +141,7 @@ module JSON
             { type: {{type_override || "number"}}, format: {{format_hint || klass.stringify}}{% if multiple_of %}, multipleOf: {{multiple_of}}{% end %}{% if minimum %}, minimum: {{minimum}}{% end %}{% if exclusive_minimum %}, exclusiveMinimum: {{exclusive_minimum}}{% end %}{% if maximum %}, maximum: {{maximum}}{% end %}{% if exclusive_maximum %}, exclusiveMaximum: {{exclusive_maximum}}{% end %}{% if description %}, description: {{description}}{% end %} }
           {% end %}
         {% elsif klass <= Nil %}
-          { type: {{type_override || "null"}}{% if format_hint %}, format: {{format_hint}}{% end %}{% if description %}, description: {{description}}{% end %} }
+          { type: {{type_override || "null"}}{% if description %}, description: {{description}}{% end %} }
         {% elsif klass <= Time %}
           { type: {{type_override || "string"}}, format: {{format_hint || "date-time"}}{% if pattern %}, pattern: {{pattern}}{% end %}{% if description %}, description: {{description}}{% end %} }
         {% elsif klass <= UUID %}

--- a/src/json-schema.cr
+++ b/src/json-schema.cr
@@ -79,9 +79,7 @@ module JSON
         {% elsif klass.union? && !openapi.nil? && nillable && klass.union_types.size == 2 %}
           {% for type in klass.union_types %}
             {% if type.stringify != "Nil" %}
-              ::JSON::Schema.introspect({{type}}, {{args}}, {{openapi}}).merge({
-                nullable: true
-              })
+              JSON.parse(::JSON::Schema.introspect({{type}}, {{args}}, {{openapi}}).to_json[0..-2] + %(,"nullable":true}))
             {% end %}
           {% end %}
         {% elsif klass.union? %}


### PR DESCRIPTION
as on some platforms this results in corrupt `to_json` string generation - using JSON::Any as the container type avoids this
